### PR TITLE
Fix command management issues

### DIFF
--- a/frontend/src/components/mindmap/CommandDialog.tsx
+++ b/frontend/src/components/mindmap/CommandDialog.tsx
@@ -115,6 +115,17 @@ export function CommandDialog({
     }
   }, [command]);
 
+  // Reset form state when dialog opens
+  useEffect(() => {
+    if (isOpen && !command) {
+      // Only reset when opening for a new command (no existing command to edit)
+      setTitle("");
+      setCommandText("");
+      setDescription("");
+      setCursorPosition(0);
+    }
+  }, [isOpen, command]);
+
   const handleInsertVariable = (variable: string) => {
     if (!commandText) {
       setCommandText(variable);

--- a/frontend/src/components/mindmap/CustomNode.tsx
+++ b/frontend/src/components/mindmap/CustomNode.tsx
@@ -23,6 +23,7 @@ import { MagicCard } from "@/components/ui/magic-card";
 import type { NodeData } from "@/types";
 import { useMindMapStore } from "@/store/mindMapStore";
 import { useTheme } from "@/components/theme-provider";
+import { useNodeCommands } from "@/hooks/api/useCommands";
 
 // Status icon mapping
 const statusIcons = {
@@ -36,6 +37,7 @@ const statusIcons = {
 
 interface CustomNodeData extends NodeData {
   label?: string;
+  projectId: string; // Add projectId to the interface
 }
 
 export const CustomNode = memo(
@@ -44,6 +46,9 @@ export const CustomNode = memo(
     const [hideTimeout, setHideTimeout] = useState<NodeJS.Timeout | null>(null);
     const reactFlowInstance = useReactFlow();
     const layoutDirection = useMindMapStore((state) => state.layoutDirection);
+
+    // Get real-time command count
+    const { data: commands = [] } = useNodeCommands(data.projectId, id);
 
     // Check if this node is in focus mode
     const nodes = reactFlowInstance.getNodes();
@@ -151,7 +156,7 @@ export const CustomNode = memo(
     const hasFindings = data.findings && data.findings.trim().length > 0;
     const hasDescription =
       data.description && data.description.trim().length > 0;
-    const hasCommands = data.commands && data.commands.length > 0;
+    const hasCommands = commands && commands.length > 0; // Use live command data
     const hasContent = hasFindings || hasDescription || hasCommands;
 
     return (
@@ -210,7 +215,7 @@ export const CustomNode = memo(
                 )}
               >
                 <Terminal className="h-3 w-3" />
-                <span>{data.commands.length}</span>
+                <span>{commands.length}</span> {/* Use live command count */}
               </div>
             )}
           </div>

--- a/frontend/src/components/mindmap/MindMapEditor.tsx
+++ b/frontend/src/components/mindmap/MindMapEditor.tsx
@@ -1446,6 +1446,7 @@ export function MindMapEditor({
         data: {
           ...node,
           label: node.title,
+          projectId, // Add projectId to node data
         },
       }));
 
@@ -1538,6 +1539,7 @@ export function MindMapEditor({
               data: {
                 ...node,
                 label: node.title,
+                projectId, // Add projectId to node data
               },
             };
           });
@@ -1565,6 +1567,7 @@ export function MindMapEditor({
               data: {
                 ...apiNode,
                 label: apiNode.title,
+                projectId, // Add projectId to node data
               },
             };
           }

--- a/frontend/src/components/mindmap/NodeDetailsDrawer.tsx
+++ b/frontend/src/components/mindmap/NodeDetailsDrawer.tsx
@@ -119,7 +119,10 @@ export function NodeDetailsDrawer({
   const { setNodes } = useReactFlow();
 
   // Command hooks
-  const commands = node?.commands || [];
+  const { data: commands = [] } = useNodeCommands(
+    projectId,
+    selectedNodeId || ""
+  );
   const createCommand = useCreateCommand();
   const updateCommand = useUpdateCommand();
   const deleteCommand = useDeleteCommand();
@@ -409,6 +412,13 @@ export function NodeDetailsDrawer({
     2000 // Increased to 2 seconds for better UX
   );
 
+  // Reset command dialog state when selected node changes
+  useEffect(() => {
+    setShowCommandDialog(false);
+    setEditingCommand(undefined);
+    setExpandedCommands(new Set());
+  }, [selectedNodeId]);
+
   // Handle title save
   const handleTitleSave = async () => {
     if (!selectedNodeId) return;
@@ -582,6 +592,7 @@ export function NodeDetailsDrawer({
         },
       });
       setShowCommandDialog(false);
+      setEditingCommand(undefined); // Reset the editing command
     } catch (error) {
       // Error toast is handled by the hook
     }
@@ -635,8 +646,12 @@ export function NodeDetailsDrawer({
   };
 
   const handleAddCommand = () => {
+    // Ensure state is completely reset before opening dialog
     setEditingCommand(undefined);
-    setShowCommandDialog(true);
+    // Use setTimeout to ensure state update has processed
+    setTimeout(() => {
+      setShowCommandDialog(true);
+    }, 0);
   };
 
   // Toggle command expand/collapse
@@ -1397,10 +1412,15 @@ export function NodeDetailsDrawer({
       {/* Command Dialog */}
       {selectedNodeId && (
         <CommandDialog
+          key={editingCommand?.id || 'new-command'}
           isOpen={showCommandDialog}
           onClose={() => {
+            console.log("CommandDialog onClose called, resetting state");
+            // Reset all dialog-related state
             setShowCommandDialog(false);
             setEditingCommand(undefined);
+            // Also reset any expanded commands
+            setExpandedCommands(new Set());
           }}
           projectId={projectId}
           nodeId={selectedNodeId}


### PR DESCRIPTION
## Summary
Fixes command management bugs in NodeDetailsDrawer:
- Commands not appearing after creation (required page refresh)
- Form showing previous data when adding new commands
- Command counts not updating in real-time

## Changes
- Use `useNodeCommands()` hook for real-time data instead of cached `node.commands`
- Reset form state when CommandDialog opens for new commands
- Pass `projectId` to CustomNode for live command count display

## Files
- `NodeDetailsDrawer.tsx` - Real-time queries + state cleanup
- `CommandDialog.tsx` - Form reset logic  
- `MindMapEditor.tsx` + `CustomNode.tsx` - Live command counts
